### PR TITLE
Remove UglifyJs plugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const webpack = require('webpack');
+const TerserPlugin = require('terser-webpack-plugin');
 const { options: postgraphileOptions } = require('./src/postgraphileOptions.js');
 
 module.exports = {
@@ -41,5 +42,16 @@ module.exports = {
   ],
   node: {
     __dirname: false, // just output `__dirname`
+  },
+  optimization: {
+    minimizer: [
+      new TerserPlugin({
+        terserOptions: {
+          // Without this, you may get errors such as
+          // `Error: GraphQL conflict for 'e' detected! Multiple versions of graphql exist in your node_modules?`
+          mangle: false,
+        },
+      }),
+    ],
   },
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const webpack = require('webpack');
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const { options: postgraphileOptions } = require('./src/postgraphileOptions.js');
 
 module.exports = {
@@ -42,16 +41,5 @@ module.exports = {
   ],
   node: {
     __dirname: false, // just output `__dirname`
-  },
-  optimization: {
-    minimizer: [
-      new UglifyJsPlugin({
-        uglifyOptions: {
-          // Without this, you may get errors such as
-          // `Error: GraphQL conflict for 'e' detected! Multiple versions of graphql exist in your node_modules?`
-          mangle: false,
-        },
-      }),
-    ],
   },
 };


### PR DESCRIPTION
With the following configuration:

```
$ node -v
v10.15.3
$ yarn -v
1.16.0
```

I was getting the following error during build:

```
$ yarn build
yarn run v1.16.0
warning package.json: No license field
$ . ./.env && scripts/build && scripts/generate-cache && scripts/bundle
warning package.json: No license field
$ webpack
Hash: 496838d3120579cf42dc
Version: webpack 4.29.6
Time: 2097ms
Built at: 05/26/2019 12:40:21 PM
 1 asset
Entrypoint main = index.js
 [17] external "util" 42 bytes {0} [built]
 [30] external "stream" 42 bytes {0} [built]
 [33] external "events" 42 bytes {0} [built]
 [36] ./node_modules/graphql/index.mjs + 71 modules 369 KiB {0} [built]
      |    72 modules
 [44] ./node_modules/graphql/error/index.mjs + 1 modules 1.26 KiB {0} [built]
      |    2 modules
 [48] external "path" 42 bytes {0} [built]
 [49] external "fs" 42 bytes {0} [built]
 [62] external "assert" 42 bytes {0} [built]
 [63] external "crypto" 42 bytes {0} [built]
 [81] external "url" 42 bytes {0} [built]
[172] ./node_modules/postgraphile/build/postgraphile/http/subscriptions.js 62 bytes {0} [built]
[173] ./src/index.js 2.07 KiB {0} [built]
[176] external "http" 42 bytes {0} [built]
[463] ./src/postgraphileOptions.js 665 bytes {0} [built]
[464] ./src/combineMiddlewares.js 706 bytes {0} [built]
    + 453 hidden modules

ERROR in index.js from UglifyJs
Unexpected token: name «colourIndex», expected: punc «;» [index.js:17404,6]
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Bu the way, Webpack have the Terser plugin downloaded by default as its dependency, so is it required to apply UglifyJS? With the suggested changes the package is built and run successfully. 